### PR TITLE
Call Behavior#init function before any event binding

### DIFF
--- a/src/behavior.js
+++ b/src/behavior.js
@@ -53,12 +53,12 @@ Essential.Behavior = Proto.extend({
   },
 
   start: function() {
-    this.delegateEvents();
-    this.listenChannels();
-
     if(typeof this.init === "function") {
       this.init();
     }
+
+    this.delegateEvents();
+    this.listenChannels();
   },
 
   // Delegate Events

--- a/test/behavior_test.js
+++ b/test/behavior_test.js
@@ -71,6 +71,20 @@ describe("Essential.Behavior", function() {
         expect(behavior).to.be.ok;
       });
     });
+
+    it("executes the init function before any bindings", function() {
+      var Behavior = customBehavior.extend({
+        init: function() {
+          this.el.innerHTML = "<li id='created-on-init'></li>";
+        }
+      });
+
+      var instanceBehavior = Behavior.new(this.domElement);
+      var clickTester = document.getElementById("created-on-init");
+      clickTester.dispatchEvent(Events.click());
+
+      expect(Helper.flag).to.not.equal(0);
+    });
   });
 
   it("has a default priority equal to zero", function() {


### PR DESCRIPTION
This allows to define new elements and contents for the behavior element
on initialization.

Fixes #29.
